### PR TITLE
Fixing error when the user try to delete all results of a table

### DIFF
--- a/utility.hpp
+++ b/utility.hpp
@@ -169,10 +169,9 @@ namespace ormpp{
         constexpr auto SIZE = iguana::get_value<T>();
         constexpr auto name = iguana::get_name<T>();
         append(sql, name.data());
-		//if constexpr (sizeof...(Args) > 0) {
-			//if (!is_empty(std::forward<Args>(where_conditon)...))//fix for vs2017
-				append(sql, " where ", std::forward<Args>(where_conditon)...);
-		//}        
+		auto countOfConditions = sizeof...(Args);
+		if (countOfConditions > 0)
+			append(sql, " where ", std::forward<Args>(where_conditon)...);      
 
         return sql;
     }


### PR DESCRIPTION
There is an error when the user try to delete all values of an table.
This correction fix this error.