### PR TITLE
remove constexpr in some non-constexpr environment

### DIFF
--- a/mysql.hpp
+++ b/mysql.hpp
@@ -79,7 +79,7 @@ namespace ormpp {
 		}
 
 		template<typename T, typename... Args >
-		constexpr bool create_datatable(Args&&... args) {
+		bool create_datatable(Args&&... args) {
 			std::string sql = generate_createtb_sql<T>(std::forward<Args>(args)...);
 			sql += " DEFAULT CHARSET=utf8";
 			if (mysql_query(con_, sql.data())) {
@@ -91,7 +91,7 @@ namespace ormpp {
 		}
 
 		template<typename T, typename... Args>
-		constexpr int insert(const std::vector<T>& t, Args&&... args) {
+		int insert(const std::vector<T>& t, Args&&... args) {
 			auto name = get_name<T>();
 			std::string sql = auto_key_map_[name].empty() ? generate_insert_sql<T>(false) : generate_auto_insert_sql<T>(auto_key_map_, false);
 
@@ -99,14 +99,14 @@ namespace ormpp {
 		}
 
 		template<typename T, typename... Args>
-		constexpr int update(const std::vector<T>& t, Args&&... args) {
+		int update(const std::vector<T>& t, Args&&... args) {
 			std::string sql = generate_insert_sql<T>(true);
 
 			return insert_impl(sql, t, std::forward<Args>(args)...);
 		}
 
 		template<typename T, typename... Args>
-		constexpr int insert(const T& t, Args&&... args) {
+		int insert(const T& t, Args&&... args) {
 			//insert into person values(?, ?, ?);
 			auto name = get_name<T>();
 			std::string sql = auto_key_map_[name].empty() ? generate_insert_sql<T>(false) : generate_auto_insert_sql<T>(auto_key_map_, false);
@@ -115,13 +115,13 @@ namespace ormpp {
 		}
 
 		template<typename T, typename... Args>
-		constexpr int update(const T& t, Args&&... args) {
+		int update(const T& t, Args&&... args) {
 			std::string sql = generate_insert_sql<T>(true);
 			return insert_impl(sql, t, std::forward<Args>(args)...);
 		}
 
 		template<typename T, typename... Args>
-		constexpr bool delete_records(Args&&... where_conditon) {
+		bool delete_records(Args&&... where_conditon) {
 			auto sql = generate_delete_sql<T>(std::forward<Args>(where_conditon)...);
 			if (mysql_query(con_, sql.data())) {
 				fprintf(stderr, "%s\n", mysql_error(con_));
@@ -137,7 +137,7 @@ namespace ormpp {
 
 		//for tuple and string with args...
 		template<typename T, typename Arg, typename... Args>
-		constexpr std::enable_if_t<!iguana::is_reflection_v<T>, std::vector<T>> query(const Arg& s, Args&&... args) {
+		std::enable_if_t<!iguana::is_reflection_v<T>, std::vector<T>> query(const Arg& s, Args&&... args) {
 			static_assert(iguana::is_tuple<T>::value);
 			constexpr auto SIZE = std::tuple_size_v<T>;
 
@@ -271,7 +271,7 @@ namespace ormpp {
 
 		//if there is a sql error, how to tell the user? throw exception?
 		template<typename T, typename... Args>
-		constexpr std::enable_if_t<iguana::is_reflection_v<T>, std::vector<T>> query(Args&&... args) {
+		std::enable_if_t<iguana::is_reflection_v<T>, std::vector<T>> query(Args&&... args) {
 			std::string sql = generate_query_sql<T>(args...);
 			constexpr auto SIZE = iguana::get_value<T>();
 
@@ -557,7 +557,7 @@ namespace ormpp {
 		};
 
 		template<typename T, typename... Args>
-		constexpr int insert_impl(const std::string& sql, const T& t, Args&&... args) {
+		int insert_impl(const std::string& sql, const T& t, Args&&... args) {
 			stmt_ = mysql_stmt_init(con_);
 			if (!stmt_)
 				return INT_MIN;
@@ -575,7 +575,7 @@ namespace ormpp {
 		}
 
 		template<typename T, typename... Args>
-		constexpr int insert_impl(const std::string& sql, const std::vector<T>& t, Args&&... args) {
+		int insert_impl(const std::string& sql, const std::vector<T>& t, Args&&... args) {
 			stmt_ = mysql_stmt_init(con_);
 			if (!stmt_)
 				return INT_MIN;

--- a/type_mapping.hpp
+++ b/type_mapping.hpp
@@ -49,7 +49,7 @@ namespace ormpp{
 		inline constexpr auto type_to_name(identity<int64_t>) noexcept { return "BIGINT"sv; }
 		inline auto type_to_name(identity<std::string>) noexcept { return "TEXT"sv; }
 		template<size_t N>
-		inline constexpr auto type_to_name(identity<std::array<char, N>>) noexcept {
+		inline auto type_to_name(identity<std::array<char, N>>) noexcept {
 			std::string s = "varchar(" + std::to_string(N) + ")";
 			return s;
 		}
@@ -72,7 +72,7 @@ namespace ormpp{
 		inline constexpr auto type_to_name(identity<int64_t>) noexcept { return "INTEGER"sv; }
 		inline auto type_to_name(identity<std::string>) noexcept { return "TEXT"sv; }
 		template<size_t N>
-		inline constexpr auto type_to_name(identity<std::array<char, N>>) noexcept {
+		inline auto type_to_name(identity<std::array<char, N>>) noexcept {
 			std::string s = "varchar(" + std::to_string(N) + ")";
 			return s;
 		}
@@ -100,7 +100,7 @@ namespace ormpp{
 		inline constexpr auto type_to_name(identity<int64_t>) noexcept { return "bigint"sv; }
 		inline auto type_to_name(identity<std::string>) noexcept { return "text"sv; }
 		template<size_t N>
-		inline constexpr auto type_to_name(identity<std::array<char, N>>) noexcept {
+		inline auto type_to_name(identity<std::array<char, N>>) noexcept {
 			std::string s = "varchar(" + std::to_string(N)+")";
 			return s;
 		}


### PR DESCRIPTION
In MacOS with Clang, the code will fail to compile because `std::string` doesn't provide a constexpr constuctor so that it can not be in constexpr environment. Remove some usage of `constexpr` to extinguish such bugs.