### PR TITLE
hey just a pr

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@
 *.exe
 *.out
 *.app
+.idea/

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,2 +1,0 @@
-# Default ignored files
-/workspace.xml

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,2 @@
+# Default ignored files
+/workspace.xml

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="CMakeWorkspace" PROJECT_DIR="$PROJECT_DIR$" />
-</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="ProjectModuleManager">
-    <modules>
-      <module fileurl="file://$PROJECT_DIR$/.idea/ormpp.iml" filepath="$PROJECT_DIR$/.idea/ormpp.iml" />
-    </modules>
-  </component>
-</project>

--- a/.idea/ormpp.iml
+++ b/.idea/ormpp.iml
@@ -1,2 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<module classpath="CMake" type="CPP_MODULE" version="4" />

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="VcsDirectoryMappings">
-    <mapping directory="$PROJECT_DIR$" vcs="Git" />
-  </component>
-</project>

--- a/utility.hpp
+++ b/utility.hpp
@@ -92,6 +92,10 @@ namespace ormpp{
                 case DBType::postgresql : s = ormpp_postgresql::type_to_name(identity<U>{});
                     break;
 #endif
+                case DBType::sqlite:
+                    break;
+                case DBType::postgresql:
+                    break;
             }
 
             arr[Idx] = s;


### PR DESCRIPTION
提个PR、 顺便求助一下， 我用mac 编译报错，信息如下：
```bash
====================[ Build | ormpp | Debug ]===================================
/Applications/CLion.app/Contents/bin/cmake/mac/bin/cmake --build /Users/sato/Documents/C/ormpp/cmake-build-debug --target ormpp -- -j 6
[ 50%] Building CXX object CMakeFiles/ormpp.dir/main.cpp.o
In file included from /Users/sato/Documents/C/ormpp/main.cpp:13:
In file included from /Users/sato/Documents/C/ormpp/mysql.hpp:13:
/Users/sato/Documents/C/ormpp/type_mapping.hpp:53:16: error: variable of non-literal type 'std::string' (aka 'basic_string<char, char_traits<char>, allocator<char> >') cannot be defined in a constexpr function
                        std::string s = "varchar(" + std::to_string(N) + ")";
                                    ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/string:4333:64: note: 'basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >' is not literal because it is not an aggregate and has no constexpr constructors other than copy or move constructors
_LIBCPP_EXTERN_TEMPLATE(class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS basic_string<char>)
                                                               ^
In file included from /Users/sato/Documents/C/ormpp/main.cpp:13:
/Users/sato/Documents/C/ormpp/mysql.hpp:83:16: error: variable of non-literal type 'std::string' (aka 'basic_string<char, char_traits<char>, allocator<char> >') cannot be defined in a constexpr function
                        std::string sql = generate_createtb_sql<T>(std::forward<Args>(args)...);
                                    ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/string:4333:64: note: 'basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >' is not literal because it is not an aggregate and has no constexpr constructors other than copy or move constructors
_LIBCPP_EXTERN_TEMPLATE(class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS basic_string<char>)
                                                               ^
In file included from /Users/sato/Documents/C/ormpp/main.cpp:13:
/Users/sato/Documents/C/ormpp/mysql.hpp:96:16: error: variable of non-literal type 'std::string' (aka 'basic_string<char, char_traits<char>, allocator<char> >') cannot be defined in a constexpr function
                        std::string sql = auto_key_map_[name].empty() ? generate_insert_sql<T>(false) : generate_auto_insert_sql<T>(auto_key_map_, false);
                                    ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/string:4333:64: note: 'basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >' is not literal because it is not an aggregate and has no constexpr constructors other than copy or move constructors
_LIBCPP_EXTERN_TEMPLATE(class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS basic_string<char>)
                                                               ^
In file included from /Users/sato/Documents/C/ormpp/main.cpp:13:
/Users/sato/Documents/C/ormpp/mysql.hpp:103:16: error: variable of non-literal type 'std::string' (aka 'basic_string<char, char_traits<char>, allocator<char> >') cannot be defined in a constexpr function
                        std::string sql = generate_insert_sql<T>(true);
                                    ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/string:4333:64: note: 'basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >' is not literal because it is not an aggregate and has no constexpr constructors other than copy or move constructors
_LIBCPP_EXTERN_TEMPLATE(class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS basic_string<char>)
                                                               ^
In file included from /Users/sato/Documents/C/ormpp/main.cpp:13:
/Users/sato/Documents/C/ormpp/mysql.hpp:112:16: error: variable of non-literal type 'std::string' (aka 'basic_string<char, char_traits<char>, allocator<char> >') cannot be defined in a constexpr function
                        std::string sql = auto_key_map_[name].empty() ? generate_insert_sql<T>(false) : generate_auto_insert_sql<T>(auto_key_map_, false);
                                    ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/string:4333:64: note: 'basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >' is not literal because it is not an aggregate and has no constexpr constructors other than copy or move constructors
_LIBCPP_EXTERN_TEMPLATE(class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS basic_string<char>)
                                                               ^
In file included from /Users/sato/Documents/C/ormpp/main.cpp:13:
/Users/sato/Documents/C/ormpp/mysql.hpp:119:16: error: variable of non-literal type 'std::string' (aka 'basic_string<char, char_traits<char>, allocator<char> >') cannot be defined in a constexpr function
                        std::string sql = generate_insert_sql<T>(true);
                                    ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/string:4333:64: note: 'basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >' is not literal because it is not an aggregate and has no constexpr constructors other than copy or move constructors
_LIBCPP_EXTERN_TEMPLATE(class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS basic_string<char>)
                                                               ^
In file included from /Users/sato/Documents/C/ormpp/main.cpp:13:
/Users/sato/Documents/C/ormpp/mysql.hpp:144:16: error: variable of non-literal type 'std::string' (aka 'basic_string<char, char_traits<char>, allocator<char> >') cannot be defined in a constexpr function
                        std::string sql = s;
                                    ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/string:4333:64: note: 'basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >' is not literal because it is not an aggregate and has no constexpr constructors other than copy or move constructors
_LIBCPP_EXTERN_TEMPLATE(class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS basic_string<char>)
                                                               ^
In file included from /Users/sato/Documents/C/ormpp/main.cpp:13:
/Users/sato/Documents/C/ormpp/mysql.hpp:275:16: error: variable of non-literal type 'std::string' (aka 'basic_string<char, char_traits<char>, allocator<char> >') cannot be defined in a constexpr function
                        std::string sql = generate_query_sql<T>(args...);
                                    ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/string:4333:64: note: 'basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >' is not literal because it is not an aggregate and has no constexpr constructors other than copy or move constructors
_LIBCPP_EXTERN_TEMPLATE(class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS basic_string<char>)
                                                               ^
In file included from /Users/sato/Documents/C/ormpp/main.cpp:13:
/Users/sato/Documents/C/ormpp/mysql.hpp:569:9: error: variable of non-literal type 'ormpp::mysql::guard_statment' cannot be defined in a constexpr function
                        auto guard = guard_statment(stmt_);
                             ^
/Users/sato/Documents/C/ormpp/mysql.hpp:546:10: note: 'guard_statment' is not literal because it is not an aggregate and has no constexpr constructors other than copy or move constructors
                struct guard_statment {
                       ^
/Users/sato/Documents/C/ormpp/mysql.hpp:587:9: error: variable of non-literal type 'ormpp::mysql::guard_statment' cannot be defined in a constexpr function
                        auto guard = guard_statment(stmt_);
                             ^
/Users/sato/Documents/C/ormpp/mysql.hpp:546:10: note: 'guard_statment' is not literal because it is not an aggregate and has no constexpr constructors other than copy or move constructors
                struct guard_statment {
                       ^
In file included from /Users/sato/Documents/C/ormpp/main.cpp:24:
/Users/sato/Documents/C/ormpp/dbng.hpp:65:33: error: no matching member function for call to 'query'
            return db_.template query<T>(std::forward<Args>(args)...);
                   ~~~~~~~~~~~~~^~~~~~~~
/Users/sato/Documents/C/ormpp/main.cpp:151:27: note: in instantiation of function template specialization 'ormpp::dbng<ormpp::mysql>::query<student>' requested here
    auto result1 = conn1->query<student>();
                          ^
/Users/sato/Documents/C/ormpp/mysql.hpp:274:74: note: candidate template ignored: substitution failure [with T = student, Args = <>]
                constexpr std::enable_if_t<iguana::is_reflection_v<T>, std::vector<T>> query(Args&&... args) {
                                                                                       ^
/Users/sato/Documents/C/ormpp/mysql.hpp:140:75: note: candidate function template not viable: requires at least argument 's', but no arguments were provided
                constexpr std::enable_if_t<!iguana::is_reflection_v<T>, std::vector<T>> query(const Arg& s, Args&&... args) {
                                                                                        ^
In file included from /Users/sato/Documents/C/ormpp/main.cpp:24:
/Users/sato/Documents/C/ormpp/dbng.hpp:34:33: error: no matching member function for call to 'create_datatable'
            return db_.template create_datatable<T>(std::forward<Args>(args)...);
                   ~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~
/Users/sato/Documents/C/ormpp/main.cpp:254:24: note: in instantiation of function template specialization 'ormpp::dbng<ormpp::mysql>::create_datatable<person>' requested here
    TEST_REQUIRE(mysql.create_datatable<person>());
                       ^
/Users/sato/Documents/C/ormpp/mysql.hpp:82:18: note: candidate template ignored: substitution failure [with T = person, Args = <>]
                constexpr bool create_datatable(Args&&... args) {
                               ^
In file included from /Users/sato/Documents/C/ormpp/main.cpp:24:
/Users/sato/Documents/C/ormpp/dbng.hpp:34:33: error: no matching member function for call to 'create_datatable'
            return db_.template create_datatable<T>(std::forward<Args>(args)...);
                   ~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~
/Users/sato/Documents/C/ormpp/main.cpp:255:24: note: in instantiation of function template specialization 'ormpp::dbng<ormpp::mysql>::create_datatable<person, ormpp_key &>' requested here
    TEST_REQUIRE(mysql.create_datatable<person>(key));
                       ^
/Users/sato/Documents/C/ormpp/mysql.hpp:82:18: note: candidate template ignored: substitution failure [with T = person, Args = <ormpp_key &>]
                constexpr bool create_datatable(Args&&... args) {
                               ^
In file included from /Users/sato/Documents/C/ormpp/main.cpp:24:
/Users/sato/Documents/C/ormpp/dbng.hpp:34:33: error: no matching member function for call to 'create_datatable'
            return db_.template create_datatable<T>(std::forward<Args>(args)...);
                   ~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~
/Users/sato/Documents/C/ormpp/main.cpp:256:24: note: in instantiation of function template specialization 'ormpp::dbng<ormpp::mysql>::create_datatable<person, ormpp_not_null &>' requested here
    TEST_REQUIRE(mysql.create_datatable<person>(not_null));
                       ^
/Users/sato/Documents/C/ormpp/mysql.hpp:82:18: note: candidate template ignored: substitution failure [with T = person, Args = <ormpp_not_null &>]
                constexpr bool create_datatable(Args&&... args) {
                               ^
In file included from /Users/sato/Documents/C/ormpp/main.cpp:24:
/Users/sato/Documents/C/ormpp/dbng.hpp:34:33: error: no matching member function for call to 'create_datatable'
            return db_.template create_datatable<T>(std::forward<Args>(args)...);
                   ~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~
/Users/sato/Documents/C/ormpp/main.cpp:257:24: note: in instantiation of function template specialization 'ormpp::dbng<ormpp::mysql>::create_datatable<person, ormpp_key &, ormpp_not_null &>' requested here
    TEST_REQUIRE(mysql.create_datatable<person>(key, not_null));
                       ^
/Users/sato/Documents/C/ormpp/mysql.hpp:82:18: note: candidate template ignored: substitution failure [with T = person, Args = <ormpp_key &, ormpp_not_null &>]
                constexpr bool create_datatable(Args&&... args) {
                               ^
In file included from /Users/sato/Documents/C/ormpp/main.cpp:24:
/Users/sato/Documents/C/ormpp/dbng.hpp:34:33: error: no matching member function for call to 'create_datatable'
            return db_.template create_datatable<T>(std::forward<Args>(args)...);
                   ~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~
/Users/sato/Documents/C/ormpp/main.cpp:258:24: note: in instantiation of function template specialization 'ormpp::dbng<ormpp::mysql>::create_datatable<person, ormpp_not_null &, ormpp_key &>' requested here
    TEST_REQUIRE(mysql.create_datatable<person>(not_null, key));
                       ^
/Users/sato/Documents/C/ormpp/mysql.hpp:82:18: note: candidate template ignored: substitution failure [with T = person, Args = <ormpp_not_null &, ormpp_key &>]
                constexpr bool create_datatable(Args&&... args) {
                               ^
In file included from /Users/sato/Documents/C/ormpp/main.cpp:24:
/Users/sato/Documents/C/ormpp/dbng.hpp:34:33: error: no matching member function for call to 'create_datatable'
            return db_.template create_datatable<T>(std::forward<Args>(args)...);
                   ~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~
/Users/sato/Documents/C/ormpp/main.cpp:259:24: note: in instantiation of function template specialization 'ormpp::dbng<ormpp::mysql>::create_datatable<person, ormpp_auto_key &>' requested here
    TEST_REQUIRE(mysql.create_datatable<person>(auto_key));
                       ^
/Users/sato/Documents/C/ormpp/mysql.hpp:82:18: note: candidate template ignored: substitution failure [with T = person, Args = <ormpp_auto_key &>]
                constexpr bool create_datatable(Args&&... args) {
                               ^
In file included from /Users/sato/Documents/C/ormpp/main.cpp:24:
/Users/sato/Documents/C/ormpp/dbng.hpp:34:33: error: no matching member function for call to 'create_datatable'
            return db_.template create_datatable<T>(std::forward<Args>(args)...);
                   ~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~
/Users/sato/Documents/C/ormpp/main.cpp:260:24: note: in instantiation of function template specialization 'ormpp::dbng<ormpp::mysql>::create_datatable<person, ormpp_auto_key &, ormpp_not_null &>' requested here
    TEST_REQUIRE(mysql.create_datatable<person>(auto_key, not_null));
                       ^
/Users/sato/Documents/C/ormpp/mysql.hpp:82:18: note: candidate template ignored: substitution failure [with T = person, Args = <ormpp_auto_key &, ormpp_not_null &>]
                constexpr bool create_datatable(Args&&... args) {
                               ^
In file included from /Users/sato/Documents/C/ormpp/main.cpp:24:
/Users/sato/Documents/C/ormpp/dbng.hpp:34:33: error: no matching member function for call to 'create_datatable'
            return db_.template create_datatable<T>(std::forward<Args>(args)...);
                   ~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~
/Users/sato/Documents/C/ormpp/main.cpp:261:24: note: in instantiation of function template specialization 'ormpp::dbng<ormpp::mysql>::create_datatable<person, ormpp_not_null &, ormpp_auto_key &>' requested here
    TEST_REQUIRE(mysql.create_datatable<person>(not_null, auto_key));
                       ^
/Users/sato/Documents/C/ormpp/mysql.hpp:82:18: note: candidate template ignored: substitution failure [with T = person, Args = <ormpp_not_null &, ormpp_auto_key &>]
                constexpr bool create_datatable(Args&&... args) {
                               ^
fatal error: too many errors emitted, stopping now [-ferror-limit=]
20 errors generated.
make[3]: *** [CMakeFiles/ormpp.dir/main.cpp.o] Error 1
make[2]: *** [CMakeFiles/ormpp.dir/all] Error 2
make[1]: *** [CMakeFiles/ormpp.dir/rule] Error 2
make: *** [ormpp] Error 2
```
是哪个版本不对吗？