### PR TITLE
Correction of Spelling Error: "conditon" to "condition"

### DIFF
--- a/include/dbng.hpp
+++ b/include/dbng.hpp
@@ -74,9 +74,9 @@ class dbng {
   }
 
   template <typename T, typename... Args>
-  bool delete_records(Args &&...where_conditon) {
+  bool delete_records(Args &&...where_condition) {
     return db_.template delete_records<T>(
-        std::forward<Args>(where_conditon)...);
+        std::forward<Args>(where_condition)...);
   }
 
   // restriction, all the args are string, the first is the where condition,


### PR DESCRIPTION
his pull request aims to correct a spelling error in the codebase, specifically the word "conditon" which should be "condition". The change is minimal and will not affect the functionality of the code.