### PR TITLE
修复bug：在MSVC debug环境下，直接value解引用会触发cannot access empty value optional断…

### DIFF
--- a/ormpp/mysql.hpp
+++ b/ormpp/mysql.hpp
@@ -210,7 +210,7 @@ class mysql {
     using U = std::remove_const_t<std::remove_reference_t<T>>;
     if constexpr (is_optional_v<U>::value) {
       using value_type = typename U::value_type;
-      if(!value.has_value()) {
+      if (!value.has_value()) {
         value = value_type{};
       }
       return set_param_bind(param_bind, *value, i, mp, is_null);

--- a/ormpp/mysql.hpp
+++ b/ormpp/mysql.hpp
@@ -209,6 +209,8 @@ class mysql {
                       std::map<size_t, std::vector<char>> &mp, B &is_null) {
     using U = std::remove_const_t<std::remove_reference_t<T>>;
     if constexpr (is_optional_v<U>::value) {
+      using value_type = typename U::value_type;
+      value = value_type();
       return set_param_bind(param_bind, *value, i, mp, is_null);
     }
     else if constexpr (std::is_enum_v<U>) {

--- a/ormpp/mysql.hpp
+++ b/ormpp/mysql.hpp
@@ -210,7 +210,9 @@ class mysql {
     using U = std::remove_const_t<std::remove_reference_t<T>>;
     if constexpr (is_optional_v<U>::value) {
       using value_type = typename U::value_type;
-      value = value_type();
+      if(!value.has_value()) {
+        value = value_type{};
+      }
       return set_param_bind(param_bind, *value, i, mp, is_null);
     }
     else if constexpr (std::is_enum_v<U>) {

--- a/tests/test_ormpp.cpp
+++ b/tests/test_ormpp.cpp
@@ -121,6 +121,18 @@ TEST_CASE("optional") {
     CHECK(vec2.front().age.value() == 200);
     CHECK(vec2.front().name.value() == "purecpp");
     CHECK(vec2.front().empty_.has_value() == false);
+
+    auto vec3 = mysql.query_s<test_optional>();
+    REQUIRE(vec3.size() > 0);
+    CHECK(vec3.front().age.value() == 200);
+    CHECK(vec3.front().name.value() == "purecpp");
+    CHECK(vec3.front().empty_.has_value() == false);
+    auto vec4 = mysql.query_s<test_optional>("select * from test_optional;");
+    REQUIRE(vec4.size() > 0);
+    CHECK(vec4.front().age.value() == 200);
+    CHECK(vec4.front().name.value() == "purecpp");
+    CHECK(vec4.front().empty_.has_value() == false);
+
   }
 #endif
 #ifdef ORMPP_ENABLE_PG

--- a/tests/test_ormpp.cpp
+++ b/tests/test_ormpp.cpp
@@ -132,7 +132,6 @@ TEST_CASE("optional") {
     CHECK(vec4.front().age.value() == 200);
     CHECK(vec4.front().name.value() == "purecpp");
     CHECK(vec4.front().empty_.has_value() == false);
-
   }
 #endif
 #ifdef ORMPP_ENABLE_PG


### PR DESCRIPTION
…言，导致程序崩溃。
在下面的语句中value其实是一个std::optional,
```c++
set_param_bind(param_bind, *value, i, mp, is_null);
```
直接*value解引用会触发下述语句
```c++
_NODISCARD constexpr const _Ty& operator*() const& {
#if _CONTAINER_DEBUG_LEVEL > 0
        _STL_VERIFY(this->_Has_value, "Cannot access value of empty optional");
#endif // _CONTAINER_DEBUG_LEVEL > 0
        return this->_Value;
    }
```
由于debug环境下_STL_VERIFY(this->_Has_value, "Cannot access value of empty optional");断言命中程序崩溃。解决方法是在解引用之前给std::optional的value先提供一个默认值。确保断言不会触发