### PR TITLE
Use IF NOT EXISTS for PostgreSQL index creation

### DIFF
--- a/ormpp/query.hpp
+++ b/ormpp/query.hpp
@@ -1953,8 +1953,13 @@ struct alter_table_builder {
       auto sp = rest.find(' ');
       auto idx_name = rest.substr(0, sp);
       auto cols = rest.substr(sp + 1);
-      sql.append("CREATE INDEX ")
-          .append(idx_name)
+      if constexpr (db_type == DBType::postgresql) {
+        sql.append("CREATE INDEX IF NOT EXISTS ");
+      }
+      else {
+        sql.append("CREATE INDEX ");
+      }
+      sql.append(idx_name)
           .append(" ON ")
           .append(table_name)
           .append("(")

--- a/tests/test_ormpp.cpp
+++ b/tests/test_ormpp.cpp
@@ -65,6 +65,10 @@ struct builder_person {
 };
 REGISTER_AUTO_KEY(builder_person, id)
 
+struct fake_postgresql_db {
+  static constexpr DBType db_type_v = DBType::postgresql;
+};
+
 struct ormpp_partition_log {
   int id;
   int bucket;
@@ -3184,6 +3188,20 @@ TEST_CASE("builder range partition interfaces") {
                     .partition(range_partition("bad-name", 1, 2))
                     .execute());
   }
+}
+
+TEST_CASE("postgresql alter table add_index uses if not exists") {
+  alter_table_builder<builder_person, fake_postgresql_db *> builder{nullptr};
+  builder.add_index("idx_builder_person_name", col(&builder_person::name));
+
+  REQUIRE(builder.ops_.size() == 1);
+
+  std::string sql;
+  CHECK(
+      builder.build_operation_sql(builder.ops_.front(), "builder_person", sql));
+  CHECK(sql ==
+        "CREATE INDEX IF NOT EXISTS idx_builder_person_name ON "
+        "builder_person(name)");
 }
 
 #if __cplusplus >= 202002L


### PR DESCRIPTION
## Summary

- Generate `CREATE INDEX IF NOT EXISTS` for PostgreSQL `alter_table().add_index()` calls.
- Keep existing non-PostgreSQL index SQL behavior unchanged.
- Add a focused SQL generation test that does not require a live PostgreSQL connection.

## Validation

- `cmake --build .\build --config Release --target test_ormpp`
- `.\build\tests\Release\test_ormpp.exe --test-case="postgresql alter table add_index uses if not exists"`
- `.\build\tests\Release\test_ormpp.exe`