### PR TITLE
Fix update SQL generation without keys

### DIFF
--- a/ormpp/mysql.hpp
+++ b/ormpp/mysql.hpp
@@ -1164,8 +1164,8 @@ class mysql {
       set_last_error("update requires a conflict key or where condition");
       return INT_MIN;
     }
-    auto res = insert_or_update_impl<members...>(
-        t, sql, OptType::update, false, std::forward<Args>(args)...);
+    auto res = insert_or_update_impl<members...>(t, sql, OptType::update, false,
+                                                 std::forward<Args>(args)...);
     return res.has_value() ? res.value() : INT_MIN;
   }
 
@@ -1177,8 +1177,8 @@ class mysql {
       set_last_error("update requires a conflict key or where condition");
       return INT_MIN;
     }
-    auto res = insert_or_update_impl<members...>(
-        v, sql, OptType::update, false, std::forward<Args>(args)...);
+    auto res = insert_or_update_impl<members...>(v, sql, OptType::update, false,
+                                                 std::forward<Args>(args)...);
     return res.has_value() ? res.value() : INT_MIN;
   }
 

--- a/ormpp/mysql.hpp
+++ b/ormpp/mysql.hpp
@@ -1158,21 +1158,27 @@ class mysql {
 
   template <auto... members, typename T, typename... Args>
   int update_impl(const T &t, Args &&...args) {
+    auto sql = generate_update_sql<T, members...>(db_type_v,
+                                                  std::forward<Args>(args)...);
+    if (sql.empty()) {
+      set_last_error("update requires a conflict key or where condition");
+      return INT_MIN;
+    }
     auto res = insert_or_update_impl<members...>(
-        t,
-        generate_update_sql<T, members...>(db_type_v,
-                                           std::forward<Args>(args)...),
-        OptType::update, false, std::forward<Args>(args)...);
+        t, sql, OptType::update, false, std::forward<Args>(args)...);
     return res.has_value() ? res.value() : INT_MIN;
   }
 
   template <auto... members, typename T, typename... Args>
   int update_impl(const std::vector<T> &v, Args &&...args) {
+    auto sql = generate_update_sql<T, members...>(db_type_v,
+                                                  std::forward<Args>(args)...);
+    if (sql.empty()) {
+      set_last_error("update requires a conflict key or where condition");
+      return INT_MIN;
+    }
     auto res = insert_or_update_impl<members...>(
-        v,
-        generate_update_sql<T, members...>(db_type_v,
-                                           std::forward<Args>(args)...),
-        OptType::update, false, std::forward<Args>(args)...);
+        v, sql, OptType::update, false, std::forward<Args>(args)...);
     return res.has_value() ? res.value() : INT_MIN;
   }
 

--- a/ormpp/mysql_async.hpp
+++ b/ormpp/mysql_async.hpp
@@ -1248,6 +1248,10 @@ class mysql_async {
     try {
       auto sql = generate_update_sql<T, members...>(
           db_type_v, std::forward<Args>(args)...);
+      if (sql.empty()) {
+        set_last_error("update requires a conflict key or where condition");
+        co_return std::numeric_limits<int>::min();
+      }
       auto formatted = format_struct_sql<t_is_vector_false>(
           sql, t, OptType::update, std::forward<Args>(args)...);
       auto ok = co_await execute(formatted);
@@ -1263,6 +1267,10 @@ class mysql_async {
     try {
       auto sql = generate_update_sql<T, members...>(
           db_type_v, std::forward<Args>(args)...);
+      if (sql.empty()) {
+        set_last_error("update requires a conflict key or where condition");
+        co_return std::numeric_limits<int>::min();
+      }
       int affected = 0;
       if (transaction_ && !v.empty()) {
         if (!(co_await begin())) {

--- a/ormpp/postgresql.hpp
+++ b/ormpp/postgresql.hpp
@@ -648,21 +648,27 @@ class postgresql {
 
   template <auto... members, typename T, typename... Args>
   int update_impl(const T &t, Args &&...args) {
+    auto sql = generate_update_sql<T, members...>(db_type_v,
+                                                  std::forward<Args>(args)...);
+    if (sql.empty()) {
+      set_last_error("update requires a conflict key or where condition");
+      return INT_MIN;
+    }
     auto res = insert_or_update_impl<members...>(
-        t,
-        generate_update_sql<T, members...>(db_type_v,
-                                           std::forward<Args>(args)...),
-        OptType::update, false, std::forward<Args>(args)...);
+        t, sql, OptType::update, false, std::forward<Args>(args)...);
     return res.has_value() ? res.value() : INT_MIN;
   }
 
   template <auto... members, typename T, typename... Args>
   int update_impl(const std::vector<T> &v, Args &&...args) {
+    auto sql = generate_update_sql<T, members...>(db_type_v,
+                                                  std::forward<Args>(args)...);
+    if (sql.empty()) {
+      set_last_error("update requires a conflict key or where condition");
+      return INT_MIN;
+    }
     auto res = insert_or_update_impl<members...>(
-        v,
-        generate_update_sql<T, members...>(db_type_v,
-                                           std::forward<Args>(args)...),
-        OptType::update, false, std::forward<Args>(args)...);
+        v, sql, OptType::update, false, std::forward<Args>(args)...);
     return res.has_value() ? res.value() : INT_MIN;
   }
 

--- a/ormpp/postgresql.hpp
+++ b/ormpp/postgresql.hpp
@@ -654,8 +654,8 @@ class postgresql {
       set_last_error("update requires a conflict key or where condition");
       return INT_MIN;
     }
-    auto res = insert_or_update_impl<members...>(
-        t, sql, OptType::update, false, std::forward<Args>(args)...);
+    auto res = insert_or_update_impl<members...>(t, sql, OptType::update, false,
+                                                 std::forward<Args>(args)...);
     return res.has_value() ? res.value() : INT_MIN;
   }
 
@@ -667,8 +667,8 @@ class postgresql {
       set_last_error("update requires a conflict key or where condition");
       return INT_MIN;
     }
-    auto res = insert_or_update_impl<members...>(
-        v, sql, OptType::update, false, std::forward<Args>(args)...);
+    auto res = insert_or_update_impl<members...>(v, sql, OptType::update, false,
+                                                 std::forward<Args>(args)...);
     return res.has_value() ? res.value() : INT_MIN;
   }
 

--- a/ormpp/sqlite.hpp
+++ b/ormpp/sqlite.hpp
@@ -762,21 +762,27 @@ class sqlite {
 
   template <auto... members, typename T, typename... Args>
   int update_impl(const T &t, Args &&...args) {
+    auto sql = generate_update_sql<T, members...>(db_type_v,
+                                                  std::forward<Args>(args)...);
+    if (sql.empty()) {
+      set_last_error("update requires a conflict key or where condition");
+      return INT_MIN;
+    }
     auto res = insert_or_update_impl<members...>(
-        t,
-        generate_update_sql<T, members...>(db_type_v,
-                                           std::forward<Args>(args)...),
-        OptType::update, false, std::forward<Args>(args)...);
+        t, sql, OptType::update, false, std::forward<Args>(args)...);
     return res.has_value() ? res.value() : INT_MIN;
   }
 
   template <auto... members, typename T, typename... Args>
   int update_impl(const std::vector<T> &v, Args &&...args) {
+    auto sql = generate_update_sql<T, members...>(db_type_v,
+                                                  std::forward<Args>(args)...);
+    if (sql.empty()) {
+      set_last_error("update requires a conflict key or where condition");
+      return INT_MIN;
+    }
     auto res = insert_or_update_impl<members...>(
-        v,
-        generate_update_sql<T, members...>(db_type_v,
-                                           std::forward<Args>(args)...),
-        OptType::update, false, std::forward<Args>(args)...);
+        v, sql, OptType::update, false, std::forward<Args>(args)...);
     return res.has_value() ? res.value() : INT_MIN;
   }
 

--- a/ormpp/sqlite.hpp
+++ b/ormpp/sqlite.hpp
@@ -768,8 +768,8 @@ class sqlite {
       set_last_error("update requires a conflict key or where condition");
       return INT_MIN;
     }
-    auto res = insert_or_update_impl<members...>(
-        t, sql, OptType::update, false, std::forward<Args>(args)...);
+    auto res = insert_or_update_impl<members...>(t, sql, OptType::update, false,
+                                                 std::forward<Args>(args)...);
     return res.has_value() ? res.value() : INT_MIN;
   }
 
@@ -781,8 +781,8 @@ class sqlite {
       set_last_error("update requires a conflict key or where condition");
       return INT_MIN;
     }
-    auto res = insert_or_update_impl<members...>(
-        v, sql, OptType::update, false, std::forward<Args>(args)...);
+    auto res = insert_or_update_impl<members...>(v, sql, OptType::update, false,
+                                                 std::forward<Args>(args)...);
     return res.has_value() ? res.value() : INT_MIN;
   }
 

--- a/ormpp/utility.hpp
+++ b/ormpp/utility.hpp
@@ -548,12 +548,15 @@ inline std::string generate_update_sql(DBType db_type, Args &&...args) {
   fields.pop_back();
 
   std::string conflict = "where 1=1";
+  bool has_condition = false;
   if constexpr (sizeof...(Args) > 0) {
     append(conflict, " and", args...);
+    has_condition = true;
   }
   else {
     const auto &pks = get_conflict_keys<T>(db_type);
     for (const auto &it : pks) {
+      has_condition = true;
       if (db_type == DBType::postgresql) {
         append(conflict, " and", it + "=$" + std::to_string(++index));
       }
@@ -563,9 +566,14 @@ inline std::string generate_update_sql(DBType db_type, Args &&...args) {
     }
   }
 
+  if (!has_condition) {
+    return {};
+  }
+
   append(sql, fields, conflict);
-  sql.pop_back();
-  sql.pop_back();
+  while (!sql.empty() && sql.back() == ' ') {
+    sql.pop_back();
+  }
   return sql;
 }
 

--- a/tests/test_ormpp.cpp
+++ b/tests/test_ormpp.cpp
@@ -3530,7 +3530,8 @@ TEST_CASE("test get_conflict_keys function") {
   }
 }
 
-TEST_CASE("generate update sql trims trailing spaces without dropping predicates") {
+TEST_CASE(
+    "generate update sql trims trailing spaces without dropping predicates") {
   CHECK(ormpp::generate_update_sql<wuliao_index_info>(DBType::mysql) ==
         "update yj_wuliaoindex set `id`=?,`number`=? where 1=1 and `id`=?");
   CHECK(ormpp::generate_update_sql<no_key_update_info>(DBType::mysql).empty());

--- a/tests/test_ormpp.cpp
+++ b/tests/test_ormpp.cpp
@@ -57,6 +57,21 @@ struct simple {
   std::array<char, 128> arr;
 };
 
+struct wuliao_index_info {
+  int id;
+  int number;
+  static constexpr std::string_view get_alias_struct_name(wuliao_index_info *) {
+    return "yj_wuliaoindex";
+  }
+};
+REGISTER_AUTO_KEY(wuliao_index_info, id)
+
+struct no_key_update_info {
+  int id;
+  double code;
+  int age;
+};
+
 struct builder_person {
   std::string name;
   int age;
@@ -3513,6 +3528,15 @@ TEST_CASE("test get_conflict_keys function") {
     auto key6s = ormpp::get_conflict_keys<simple>(db_type);
     CHECK(key6s.empty());
   }
+}
+
+TEST_CASE("generate update sql trims trailing spaces without dropping predicates") {
+  CHECK(ormpp::generate_update_sql<wuliao_index_info>(DBType::mysql) ==
+        "update yj_wuliaoindex set `id`=?,`number`=? where 1=1 and `id`=?");
+  CHECK(ormpp::generate_update_sql<no_key_update_info>(DBType::mysql).empty());
+  CHECK(ormpp::generate_update_sql<no_key_update_info>(DBType::mysql, "id=1") ==
+        "update no_key_update_info set `id`=?,`code`=?,`age`=? where 1=1 and "
+        "id=1");
 }
 
 TEST_CASE("create table with namespace") {


### PR DESCRIPTION
## Summary

Fixes update SQL generation for cases where `update()` has neither an explicit condition nor a registered auto/conflict key.

## Root Cause

`generate_update_sql()` trimmed the generated SQL by calling `pop_back()` twice after `append()`. That happened to work when the generated predicate ended with extra spaces, but when no key was registered it dropped a real character and produced malformed SQL like `where 1=`.

## Changes

- Trim only trailing spaces from generated update SQL instead of dropping a fixed number of characters.
- Return an empty update SQL when no explicit condition and no registered key are available, avoiding accidental full-table updates.
- Add backend guards so sync MySQL, SQLite, PostgreSQL, and async MySQL fail with `INT_MIN` and a clear error instead of preparing/executing empty SQL.
- Add focused tests for the alias-table MySQL update SQL reported in #265 and the no-key fallback case.

Fixes #265.

## Validation

- `git diff --check`
- Compiled and ran focused C++20 probe for issue #265 SQL generation and no-key update SQL.
- Compiled and ran focused C++17 probe with `YLT_REFL` for the same alias-table update SQL.
- `g++ -std=c++20 -I. -x c++ - -fsyntax-only` including `ormpp/mysql_async.hpp`

Full database-backed tests were not run in this environment because the local image is missing database client development headers such as `libpq-fe.h` and MySQL C API types.