### PR TITLE
[codex] Fix select(all) query builder joins

### DIFF
--- a/ormpp/postgresql.hpp
+++ b/ormpp/postgresql.hpp
@@ -169,7 +169,8 @@ class postgresql {
   template <typename T, typename... Args>
   std::enable_if_t<iguana::ylt_refletable_v<T>, std::vector<T>> query_s(
       const std::string &str, Args &&...args) {
-    std::string sql = generate_query_sql<T>(db_type_v, str);
+    std::string sql =
+        contains_select(str) ? str : generate_query_sql<T>(db_type_v, str);
 #ifdef ORMPP_ENABLE_LOG
     std::cout << sql << std::endl;
 #endif

--- a/ormpp/query.hpp
+++ b/ormpp/query.hpp
@@ -25,6 +25,16 @@ struct where_condition {
   }
 };
 
+inline std::string qualified_field_name(std::string_view class_name,
+                                        std::string_view name) {
+  std::string str;
+  if (!class_name.empty()) {
+    str.append(class_name).append(".");
+  }
+  str.append(name);
+  return str;
+}
+
 template <typename M>
 struct col_info {
   using value_type = M;
@@ -60,17 +70,17 @@ struct col_info {
   }
 
   where_condition null() {
-    return where_condition{std::string(name), " IS ", "NULL"};
+    return where_condition{qualified_name(), " IS ", "NULL"};
   }
 
   where_condition not_null() {
-    return where_condition{std::string(name), " IS ", "NOT NULL"};
+    return where_condition{qualified_name(), " IS ", "NOT NULL"};
   }
 
   template <typename T>
   where_condition between(T left, T right) {
-    std::string str_left;
-    str_left.append(name).append(" between ").append(to_string(left));
+    std::string str_left = qualified_name();
+    str_left.append(" between ").append(to_string(left));
 
     std::string str_right;
     str_right.append(to_string(right));
@@ -81,10 +91,14 @@ struct col_info {
     static_assert(std::is_constructible_v<M, std::string> ||
                       std::is_constructible_v<M, std::string_view>,
                   "invalid type");
-    return where_condition{std::string(name), " like ", format_string(str)};
+    return where_condition{qualified_name(), " like ", format_string(str)};
   }
 
  private:
+  std::string qualified_name() const {
+    return qualified_field_name(class_name, name);
+  }
+
   static std::string format_string(std::string_view s) {
     std::string str = "'";
     str.append(escape_sql_string(s)).append("'");
@@ -108,8 +122,11 @@ struct col_info {
     (mid.append(to_string(args)).append(","), ...);
     mid.pop_back();
 
-    std::string left;
-    left.append(name).append(" ").append(s).append(" in(");
+    std::string left = qualified_name();
+    if (!s.empty()) {
+      left.append(" ").append(s);
+    }
+    left.append(" in(");
     return where_condition{left, mid, ")"};
   }
 };
@@ -448,16 +465,91 @@ std::string order_by_sql(Args... fields) {
   std::string sql = " ORDER BY ";
   (
       [&] {
-        if (fields.class_name.empty()) {
-          sql.append(fields.name);
-        }
-        else {
-          sql.append(fields.class_name).append(".").append(fields.name);
-        }
+        sql.append(qualified_field_name(fields.class_name, fields.name));
         sql.append(fields.sort_order).append(",");
       }(),
       ...);
   sql.pop_back();
+  return sql;
+}
+
+template <typename T>
+inline std::string select_all_fields_sql() {
+  std::string sql;
+  auto table_name = get_short_struct_name<T>();
+  for (const auto& name : ylt::reflection::get_member_names<T>()) {
+    sql.append(table_name).append(".").append(name).append(",");
+  }
+  if (!sql.empty()) {
+    sql.pop_back();
+  }
+  return sql;
+}
+
+inline void append_group_by_field(std::string& sql, auto field) {
+  sql.append(qualified_field_name(field.class_name, field.name)).append(",");
+}
+
+inline std::size_t find_next_postgresql_placeholder(std::string_view sql,
+                                                    std::size_t start) {
+  for (std::size_t i = start; i < sql.size(); ++i) {
+    switch (sql[i]) {
+      case '?':
+        return i;
+      case '\'':
+      case '"': {
+        const char quote = sql[i];
+        ++i;
+        while (i < sql.size()) {
+          if (sql[i] == quote) {
+            if (i + 1 < sql.size() && sql[i + 1] == quote) {
+              i += 2;
+              continue;
+            }
+            break;
+          }
+          ++i;
+        }
+        break;
+      }
+      case '-':
+        if (i + 1 < sql.size() && sql[i + 1] == '-') {
+          i += 2;
+          while (i < sql.size() && sql[i] != '\n' && sql[i] != '\r') {
+            ++i;
+          }
+        }
+        break;
+      case '/':
+        if (i + 1 < sql.size() && sql[i + 1] == '*') {
+          i += 2;
+          while (i + 1 < sql.size() && !(sql[i] == '*' && sql[i + 1] == '/')) {
+            ++i;
+          }
+          if (i + 1 < sql.size()) {
+            ++i;
+          }
+        }
+        break;
+      default:
+        break;
+    }
+  }
+  return std::string_view::npos;
+}
+
+inline std::string replace_postgresql_placeholders(std::string sql) {
+  std::size_t search_pos = 0;
+  int index = 1;
+  while (true) {
+    auto pos = find_next_postgresql_placeholder(sql, search_pos);
+    if (pos == std::string_view::npos) {
+      break;
+    }
+    std::string replacement = "$" + std::to_string(index++);
+    sql.replace(pos, 1, replacement);
+    search_pos = pos + replacement.size();
+  }
   return sql;
 }
 
@@ -549,17 +641,7 @@ class query_builder {
 
       if constexpr (std::remove_pointer_t<DB>::db_type_v ==
                     DBType::postgresql) {
-        if (sql.find('?') != std::string::npos) {
-          int index = 1;
-          for (size_t i = 0; i < sql.size(); i++) {
-            if (sql[i] == '?') {
-              sql[i] = '$';
-              std::string index_str = std::to_string(index++);
-              std::memcpy(&sql[i + 1], index_str.data(),
-                          (std::min)(index_str.size(), size_t(2)));
-            }
-          }
-        }
+        sql = replace_postgresql_placeholders(std::move(sql));
       }
 
       return sql;
@@ -863,9 +945,25 @@ class query_builder {
   template <typename... Args>
   stage_group_by group_by(Args... fields) {
     ctx_->group_by_clause_ = " GROUP BY ";
-    (ctx_->group_by_clause_.append(fields.name).append(","), ...);
+    (append_group_by_field(ctx_->group_by_clause_, fields), ...);
     ctx_->group_by_clause_.pop_back();
     return stage_group_by{ctx_};
+  }
+
+  template <typename... Args>
+  stage_order order_by(Args... fields) {
+    ctx_->order_by_clause_ = order_by_sql(fields...);
+    return stage_order{ctx_};
+  }
+
+  stage_limit limit(uint64_t n) {
+    ctx_->limit_clause_ = " LIMIT " + std::to_string(n);
+    return stage_limit{ctx_};
+  }
+
+  stage_limit limit(token_t) {
+    ctx_->limit_clause_ = " LIMIT ?  ";
+    return stage_limit{ctx_};
   }
 
   struct stage_where {
@@ -890,11 +988,7 @@ class query_builder {
     template <typename... Args>
     stage_group_by group_by(Args... fields) {
       ctx->group_by_clause_ = " GROUP BY ";
-      (ctx->group_by_clause_.append(fields.class_name)
-           .append(".")
-           .append(fields.name)
-           .append(","),
-       ...);
+      (append_group_by_field(ctx->group_by_clause_, fields), ...);
       ctx->group_by_clause_.pop_back();
       return stage_group_by{ctx};
     }
@@ -932,6 +1026,30 @@ class query_builder {
     stage_where where(const where_condition& condition) {
       ctx->where_clause_ = condition.to_sql();
       return stage_where{ctx};
+    }
+
+    template <typename... Args>
+    stage_group_by group_by(Args... fields) {
+      ctx->group_by_clause_ = " GROUP BY ";
+      (append_group_by_field(ctx->group_by_clause_, fields), ...);
+      ctx->group_by_clause_.pop_back();
+      return stage_group_by{ctx};
+    }
+
+    template <typename... Args>
+    stage_order order_by(Args... fields) {
+      ctx->order_by_clause_ = order_by_sql(fields...);
+      return stage_order{ctx};
+    }
+
+    stage_limit limit(uint64_t n) {
+      ctx->limit_clause_ = " LIMIT " + std::to_string(n);
+      return stage_limit{ctx};
+    }
+
+    stage_limit limit(token_t) {
+      ctx->limit_clause_ = " LIMIT ?  ";
+      return stage_limit{ctx};
     }
 
     template <typename To, typename... Args>
@@ -996,11 +1114,10 @@ struct stage_select {
   template <typename T>
   query_builder<T, DB, R> from() {
     auto builder = query_builder<T, DB, R>{db_};
-    if (!select_clause_.empty()) {
-      builder.ctx_->select_clause_ = select_clause_;
-      builder.ctx_->from_clause_.append(" from ").append(
-          std::string(get_short_struct_name<T>()));
-    }
+    builder.ctx_->select_clause_ =
+        select_clause_.empty() ? select_all_fields_sql<T>() : select_clause_;
+    builder.ctx_->from_clause_.append(" from ").append(
+        std::string(get_short_struct_name<T>()));
     return builder;
   }
 };

--- a/ormpp/sqlite.hpp
+++ b/ormpp/sqlite.hpp
@@ -200,7 +200,8 @@ class sqlite {
   template <typename T, typename... Args>
   std::enable_if_t<iguana::ylt_refletable_v<T>, std::vector<T>> query_s(
       const std::string &str, Args &&...args) {
-    std::string sql = generate_query_sql<T>(db_type_v, str);
+    std::string sql =
+        contains_select(str) ? str : generate_query_sql<T>(db_type_v, str);
 #ifdef ORMPP_ENABLE_LOG
     std::cout << sql << std::endl;
 #endif

--- a/ormpp/utility.hpp
+++ b/ormpp/utility.hpp
@@ -599,7 +599,7 @@ inline void get_sql_conditions(std::string &sql, const std::string &arg,
                                Args &&...args) {
   std::string temp = arg;
   std::transform(arg.begin(), arg.end(), temp.begin(), ::tolower);
-  if (temp.find("select") != std::string::npos) {
+  if (contains_select(arg)) {
     sql = arg;
   }
   else {

--- a/tests/test_ormpp.cpp
+++ b/tests/test_ormpp.cpp
@@ -186,6 +186,21 @@ struct test_optional {
 };
 REGISTER_AUTO_KEY(test_optional, id)
 
+struct Person {
+  std::string name;
+  int age;
+  int id;
+};
+REGISTER_AUTO_KEY(Person, id)
+
+struct Append {
+  int id;
+  std::optional<std::string> name;
+  std::optional<int> age;
+  std::optional<int> empty;
+};
+REGISTER_AUTO_KEY(Append, id)
+
 struct sub_optinal {
   std::optional<std::string> name;
   std::optional<int> age;
@@ -820,6 +835,29 @@ TEST_CASE("optional") {
                     .where(col(&person::id) > 0 || col(&person::id) == 1)
                     .collect();
       CHECK(l2.size() == 1);
+
+      auto all_join_rows =
+          sqlite.select(all)
+              .from<test_optional>()
+              .inner_join(col(&test_optional::id), col(&person::id))
+              .where(col(&test_optional::id) == 1)
+              .collect();
+      REQUIRE(all_join_rows.size() == 1);
+      CHECK(all_join_rows.front().id == 1);
+
+      auto grouped_all_rows = sqlite.select(all)
+                                  .from<test_optional>()
+                                  .group_by(col(&test_optional::id))
+                                  .collect();
+      CHECK(grouped_all_rows.size() == 2);
+
+      auto limited_all_rows = sqlite.select(all)
+                                  .from<test_optional>()
+                                  .order_by(col(&test_optional::id).desc())
+                                  .limit(1)
+                                  .collect();
+      REQUIRE(limited_all_rows.size() == 1);
+      CHECK(limited_all_rows.front().id == 2);
       sqlite.execute("DROP TABLE IF EXISTS person");
     }
     auto l0 = sqlite.select(all)
@@ -912,9 +950,53 @@ TEST_CASE("optional") {
 TEST_CASE("like condition quotes and escapes string patterns") {
   std::string_view pattern = "pure%";
   CHECK(col(&test_optional::name).like(pattern).to_sql() ==
-        "(name like 'pure%')");
+        "(test_optional.name like 'pure%')");
   CHECK(col(&test_optional::name).like("a'b%").to_sql() ==
-        "(name like 'a''b%')");
+        "(test_optional.name like 'a''b%')");
+}
+
+TEST_CASE("issue #269: sqlite select all with inner join") {
+  dbng<sqlite> db;
+  REQUIRE(db.connect("test_select_all_issue_269.db"));
+  db.execute("DROP TABLE IF EXISTS Person");
+  db.execute("DROP TABLE IF EXISTS Append");
+  REQUIRE(db.create_datatable<Person>());
+  REQUIRE(db.create_datatable<Append>());
+  REQUIRE(db.insert<Person>({"purecpp", 18, 0}) == 1);
+  REQUIRE(db.insert<Append>({0, "purecpp", 18, {}}) == 1);
+
+  auto ret = db.select(ormpp::all)
+                 .from<Append>()
+                 .inner_join(ormpp::col(&Person::id), ormpp::col(&Append::id))
+                 .where(ormpp::col(&Append::id) == 1)
+                 .collect();
+
+  REQUIRE(ret.size() == 1);
+  CHECK(ret.front().id == 1);
+  REQUIRE(ret.front().name.has_value());
+  CHECK(ret.front().name.value() == "purecpp");
+
+  db.execute("DROP TABLE IF EXISTS Person");
+  db.execute("DROP TABLE IF EXISTS Append");
+}
+
+TEST_CASE("query condition containing select is not treated as full SQL") {
+  CHECK(!contains_select("id in (select id from person)"));
+
+  auto sql = generate_query_sql<person>(DBType::sqlite,
+                                        "id in (select id from person)");
+  CHECK(sql.find("select ") == 0);
+  CHECK(sql.find("where 1=1 and  id in (select id from person)") !=
+        std::string::npos);
+}
+
+TEST_CASE("postgresql placeholder replacement skips SQL literals") {
+  CHECK(replace_postgresql_placeholders(
+            "select * from person where name='a?b' and id=?") ==
+        "select * from person where name='a?b' and id=$1");
+  CHECK(replace_postgresql_placeholders(
+            "select '?' as q, name from person where id=? limit ?  ") ==
+        "select '?' as q, name from person where id=$1 limit $2  ");
 }
 
 /*


### PR DESCRIPTION
## Summary

Fixes issue #269 where `select(all).from<T>().inner_join(...).where(...).collect()` could produce a partial SQL fragment that SQLite then wrapped as a `WHERE` condition, placing `JOIN` after `where 1=1 and`.

## Changes

- Make `select(all).from<T>()` build a complete `SELECT ... FROM ...` statement instead of relying on `query_s<T>` to wrap a partial condition.
- Qualify `select(all)` fields and helper-generated fields so join queries avoid ambiguous column names.
- Allow `order_by()` and `limit()` directly after `from<T>()` / `join()` for complete builder SQL paths.
- Use strict `contains_select()` checks in SQLite/PostgreSQL `query_s<T>` and `generate_query_sql()` so conditions containing subqueries are not mistaken for full SQL.
- Replace PostgreSQL `?` placeholders while skipping SQL string literals, quoted identifiers, and comments.

## Validation

- `cmake --build build --config Release --target test_ormpp`
- `build\tests\Release\test_ormpp.exe --test-case="issue #269: sqlite select all with inner join"`
- `build\tests\Release\test_ormpp.exe --test-case="optional"`
- `build\tests\Release\test_ormpp.exe --test-case="query condition containing select is not treated as full SQL"`
- `build\tests\Release\test_ormpp.exe --test-case="postgresql placeholder replacement skips SQL literals"`
- `build\tests\Release\test_ormpp.exe`